### PR TITLE
FIX: Escaped double quotes in values.

### DIFF
--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -654,7 +654,7 @@ class JSONobject
 				out = """" & year(value) & "-" & padZero(month(value), 2) & "-" & padZero(day(value), 2) & "T" & padZero(hour(value), 2) & ":" & padZero(minute(value), 2) & ":" & padZero(second(value), 2) & left(offset, 1) & padZero(mid(offset, 2), 2) & ":00"""
 			
 			case "string", "char", "empty"
-				out = """" & value & """"
+				out = """" & replace(value,"""","\""") & """"
 			
 			case else
 				out = """" & GetTypeName(value) & """"


### PR DESCRIPTION
I added the following code because I had a string value coming from the database like the following...

> abc"123

This caused a syntax error on the response to the client.
