### PR TITLE
Fix the vbTab / vbBack mess

### DIFF
--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -315,7 +315,9 @@ class JSONobject
 							case "r"
 								value = value & vbcr
 							case "t"
-								value = value & char(8)
+								value = value & vbtab
+							case "b"
+								value = value & vbback								
 							case else
 								value = value & char
 						end select
@@ -914,7 +916,7 @@ class JSONobject
 			result = replace(result, """", "\""")
 			result = replace(result, vbcr, "\r")
 			result = replace(result, vblf, "\n")
-			result = replace(result, char(8), "\t")
+			result = replace(result, vbtab, "\t")
 			result = replace(result, vbback, "\b")
 		end if
 	

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -30,6 +30,8 @@ const JSON_ERROR_PROPERTY_DOES_NOT_EXISTS = 3 ' DEPRECATED
 const JSON_ERROR_NOT_AN_ARRAY = 4
 const JSON_ERROR_INDEX_OUT_OF_BOUNDS = 9 ' Numbered to have the same error number as the default "Subscript out of range" exeption
 
+dim vbBack : vbBack = Chr(8)
+
 class JSONobject
 	dim i_debug, i_depth, i_parent
 	dim i_properties, i_version, i_defaultPropertyName


### PR DESCRIPTION
What is done with last two commits before the bump is totally wrong and harmful. 

This PR claims to fix the following problems.

- There's no built-in `vbback` constant in VBScript, it must be defined with a value `Chr(8)` explicitly.
- The parser and serializer must keep handle both backspace _(introduced with  `vbBack`)_ and tab _(built-in `vbTab`)_ characters and their escape sequences `\b` and `\t`.