### PR TITLE
Added support for outputting Javascript in serialized JSON

### DIFF
--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -1138,7 +1138,7 @@ class JSONscript
 	
 	' Constructor and destructor
 	private sub class_initialize()
-		i_version = "3.6.2"
+		i_version = "1.0.0"
 		
 		s_nullString = "null"
 		s_value = s_nullString

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -1118,7 +1118,7 @@ end class
 
 
 class JSONscript
-	dim i_parent, i_depth, 	dim i_version
+	dim i_parent, i_depth, i_version
 	dim s_value, s_nullString
 
 	' The value

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -1119,7 +1119,7 @@ end class
 
 
 class JSONscript
-	dim i_parent, i_depth, i_version
+	dim i_version
 	dim s_value, s_nullString
 
 	' The value
@@ -1136,22 +1136,9 @@ class JSONscript
 		s_value = newValue
 	end property
 	
-	' The parent object
-	public property get parent
-		set parent = i_parent
-	end property
-	
-	public property set parent(value)
-		set i_parent = value
-		i_depth = i_parent.depth + 1
-	end property
-	
 	' Constructor and destructor
 	private sub class_initialize()
 		i_version = "3.6.2"
-		
-		set i_parent = nothing
-		i_depth = 0
 		
 		s_nullString = "null"
 		s_value = s_nullString

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -657,6 +657,9 @@ class JSONobject
 			if isArray(value) or GetTypeName(value) = "JSONarray" then
 				out = out & serializeArray(value)
 				
+			elseif isObject(value) and GetTypeName(value) = "JSONscript" then
+				out = out & value.Serialize()
+
 			elseif isObject(value) then
 				out = out & serializeObject(value)
 				
@@ -1108,6 +1111,62 @@ class JSONarray
 	end function
 	
 	' Writes the serialized array to the response
+	public function Write()
+		Response.Write Serialize()
+	end function
+end class
+
+
+class JSONscript
+	dim i_parent, i_depth, 	dim i_version
+	dim s_value, s_nullString
+
+	' The value
+	public property get value
+		value = s_value
+	end property
+	
+	public property let value(newValue)
+		if (len(newValue) = 0) then newValue = s_nullString
+		s_value = newValue
+	end property
+	
+	' The parent object
+	public property get parent
+		set parent = i_parent
+	end property
+	
+	public property set parent(value)
+		set i_parent = value
+		i_depth = i_parent.depth + 1
+	end property
+	
+	' Constructor and destructor
+	private sub class_initialize()
+		i_version = "3.6.2"
+		
+		set i_parent = nothing
+		i_depth = 0
+		
+		s_nullString = "null"
+		s_value = s_nullString
+	end sub
+	
+	' Serializes this object by outputting the raw value
+	public function Serialize()
+		dim js, out, instantiated, actualLCID
+		
+		actualLCID = Response.LCID
+		Response.LCID = 1033
+		
+		out = s_value
+		
+		Response.LCID = actualLCID
+		
+		Serialize = out
+	end function
+	
+	' Writes the serialized object to the response
 	public function Write()
 		Response.Write Serialize()
 	end function

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -1154,14 +1154,9 @@ class JSONscript
 	
 	' Serializes this object by outputting the raw value
 	public function Serialize()
-		dim js, out, instantiated, actualLCID
+		dim js, out, instantiated
 		
-		actualLCID = Response.LCID
-		Response.LCID = 1033
-		
-		out = s_value
-		
-		Response.LCID = actualLCID
+		Serialize = s_value
 		
 		Serialize = out
 	end function

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -1154,11 +1154,7 @@ class JSONscript
 	
 	' Serializes this object by outputting the raw value
 	public function Serialize()
-		dim js, out, instantiated
-		
 		Serialize = s_value
-		
-		Serialize = out
 	end function
 	
 	' Writes the serialized object to the response

--- a/jsonObject.class.asp
+++ b/jsonObject.class.asp
@@ -28,6 +28,7 @@ const JSON_ERROR_PARSE = 1
 const JSON_ERROR_PROPERTY_ALREADY_EXISTS = 2
 const JSON_ERROR_PROPERTY_DOES_NOT_EXISTS = 3 ' DEPRECATED
 const JSON_ERROR_NOT_AN_ARRAY = 4
+const JSON_ERROR_NOT_A_STRING = 5
 const JSON_ERROR_INDEX_OUT_OF_BOUNDS = 9 ' Numbered to have the same error number as the default "Subscript out of range" exeption
 
 class JSONobject
@@ -1127,6 +1128,10 @@ class JSONscript
 	end property
 	
 	public property let value(newValue)
+		if (TypeName(newValue) <> "String") then
+			err.raise JSON_ERROR_NOT_A_STRING, TypeName(me), "The value assigned is not a string."
+		end if
+	
 		if (len(newValue) = 0) then newValue = s_nullString
 		s_value = newValue
 	end property

--- a/test.asp
+++ b/test.asp
@@ -254,5 +254,34 @@ Response.LCID = 1046 ' Brazilian LCID (use your locale code here).
 	set jsonObj = nothing
 	set jsonArr = nothing
 	%></pre>
+	
+	<h3>JSON Script Output</h3>
+	
+	<%
+	
+	dim realOutput
+	dim expectedOutput
+	
+	dim javascriptCode
+	dim javascriptkey
+	
+	dim jsonScr
+
+	javascriptCode = "function() { alert('test'); }"
+	javascriptKey = "script"
+	
+	expectedOutput = "{""" & javascriptKey & """:" & javascriptCode & "}"
+	
+	set jsonScr = new JSONscript
+	jsonScr.value = javascriptCode
+	
+	set jsonObj = new JSONobject
+	jsonObj.Add javascriptKey, jsonScr
+	
+	realOutput = jsonObj.Serialize()
+	
+	%><h4>Output<% if (realOutput = expectedOutput) then %> (correct)<% else %> (INCORRECT!)<% end if %></h4>
+	<pre><%= realOutput %></pre>
+	
 </body>
 </html>


### PR DESCRIPTION
I had the need to output Javascript code in my JSON. You might wonder why... Well, for example, the JSON that must be passed in to a dataLayer push for Google Tag Manager supports callback functions:

``` Javascript
<script>
/**
 * Call this function when a user clicks on a product link. This function uses the event
 * callback datalayer variable to handle navigation after the ecommerce data has been sent
 * to Google Analytics.
 * @param {Object} productObj An object representing a product.
 */
function(productObj) {
  dataLayer.push({
    'event': 'productClick',
    'ecommerce': {
      'click': {
        'actionField': {'list': 'Search Results'},      // Optional list property.
        'products': [{
          'name': productObj.name,                      // Name or ID is required.
          'id': productObj.id,
          'price': productObj.price,
          'brand': productObj.brand,
          'category': productObj.cat,
          'variant': productObj.variant,
          'position': productObj.position
         }]
       }
     },
     'eventCallback': function() {
       document.location = productObj.url
     }
  });
}
</script>
```
In this case `'eventCallback'` must be set to "raw" Javascript code. I added a JSONscript object that allows this. You set it's `value` property to a string with the code you want to insert and it will serialize that string as raw output.

I've also added a test case to `test.asp` that also demonstrates it's usage.